### PR TITLE
Re-add missing tabs in gophermaps

### DIFF
--- a/format.go
+++ b/format.go
@@ -257,6 +257,10 @@ func replaceStrings(str string, connHost *ConnHost) []byte {
 
     b := make([]byte, 0)
     for i := range split {
+        /* Re-add the tabs that we removed when splitting */
+        if (i < 3) {
+            split[i] += Tab
+        }
         b = append(b, []byte(split[i])...)
     }
     return b


### PR DESCRIPTION
While searching `development` for a fix for #13 I noticed that my gophermap looked a bit broken.

The reason seems to be that 8dae2ab splits them at tabs but fails to re-add them when joining afterwards. (I hope it's no problem to open a PR to development.)